### PR TITLE
core: add support for interrupts via epoll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "sysfs_gpio"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/posborne/rust-sysfs-gpio"
@@ -13,3 +13,6 @@ Includes a low-level interface as well as a higher-level
 and more managed interface for reading, writing, and
 polling on GPIO interrupts
 """
+
+[dependencies]
+nix = "*"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,38 +6,32 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(old_io)]
-#![feature(std_misc)]
-#![allow(deprecated)]
-
 #[macro_use]
 extern crate sysfs_gpio;
 
 use sysfs_gpio::{Direction, Pin};
-use std::time::Duration;
-use std::old_io::Timer;
+use std::thread::sleep_ms;
 use std::io;
 use std::env;
 
 struct Arguments {
     pin : u64,
-    duration_ms : i64,
-    period_ms : i64,
+    duration_ms : u32,
+    period_ms : u32,
 }
 
 // export a GPIO for use.  This will not fail
 // if already exported
-fn blink_my_led(led : u64, duration_ms : i64, period_ms : i64) -> io::Result<()> {
+fn blink_my_led(led : u64, duration_ms : u32, period_ms : u32) -> io::Result<()> {
     let my_led = Pin::new(led);
     my_led.with_exported(|| {
         try!(my_led.set_direction(Direction::Low));
-        let mut tmr = Timer::new().unwrap();
         let iterations = duration_ms / period_ms / 2;
         for _ in 0..iterations {
             try!(my_led.set_value(0));
-            tmr.sleep(Duration::milliseconds(period_ms));
+            sleep_ms(period_ms);
             try!(my_led.set_value(1));
-            tmr.sleep(Duration::milliseconds(period_ms));
+            sleep_ms(period_ms);
         }
         try!(my_led.set_value(0));
         Ok(())
@@ -52,8 +46,8 @@ fn get_args() -> Option<Arguments> {
     let args: Vec<String> = env::args().collect();
     if args.len() != 4 { return None; }
     let pin = match args[1].parse::<u64>() { Ok(pin) => pin, Err(_) => return None, };
-    let duration_ms = match args[2].parse::<i64>() { Ok(ms) => ms, Err(_) => return None, };
-    let period_ms = match args[3].parse::<i64>() { Ok(ms) => ms, Err(_) => return None, };
+    let duration_ms = match args[2].parse::<u32>() { Ok(ms) => ms, Err(_) => return None, };
+    let period_ms = match args[3].parse::<u32>() { Ok(ms) => ms, Err(_) => return None, };
     Some(Arguments { pin: pin, duration_ms: duration_ms, period_ms: period_ms, })
 }
 

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -6,17 +6,12 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(old_io)]
-#![feature(std_misc)]
-#![allow(deprecated)]
-
 extern crate sysfs_gpio;
 
 use sysfs_gpio::{Direction, Pin};
-use std::time::Duration;
-use std::old_io::Timer;
 use std::io;
 use std::env;
+use std::thread::sleep_ms;
 
 fn poll(pin_num : u64) -> io::Result<()> {
     // NOTE: this currently runs forever and as such if
@@ -27,7 +22,6 @@ fn poll(pin_num : u64) -> io::Result<()> {
     let input = Pin::new(pin_num);
     input.with_exported(|| {
         try!(input.set_direction(Direction::In));
-        let mut timer = Timer::new().unwrap();
         let mut prev_val : u8 = 255;
         loop {
             let val = try!(input.get_value());
@@ -36,7 +30,7 @@ fn poll(pin_num : u64) -> io::Result<()> {
                          if val == 0 { "Low" } else { "High" });
                 prev_val = val;
             }
-            timer.sleep(Duration::milliseconds(10));
+            sleep_ms(10);
         }
     })
 }


### PR DESCRIPTION
This is done by doing something like the following:

```rust
let mut poller = try!(pin.get_poller());
loop {
    match try!(poller.poll(1000) {
        Some(value) { println!("Pin is now {}", value) },
        None => { println!("No change after 1 second") },
    });
}
```