### PR TITLE
readme: update dependency name in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use `sysfs_gpio`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysfs-gpio = "*"
+sysfs_gpio = "*"
 ```
 
 Then, add this to your crate root:


### PR DESCRIPTION
With `sysfs-gpio` as dependecy name I got the following error

```
$ cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
no matching package named `sysfs-gpio` found (required by `gpio_test`)
location searched: registry https://github.com/rust-lang/crates.io-index
version required: *
```