### PR TITLE
derive debug for Pin and PinPoller, open file instead of creating in read_from_device_file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl Pin {
 
     fn read_from_device_file(&self, dev_file_name: &str) -> io::Result<String> {
         let gpio_path = format!("/sys/class/gpio/gpio{}/{}", self.pin_num, dev_file_name);
-        let mut dev_file = try!(File::create(&gpio_path));
+        let mut dev_file = try!(File::open(&gpio_path));
         let mut s = String::new();
         try!(dev_file.read_to_string(&mut s));
         Ok(s)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use std::fs::{File};
 mod error;
 pub use error::Error;
 
+#[derive(Debug)]
 pub struct Pin {
     pin_num : u64,
 }
@@ -325,6 +326,7 @@ impl Pin {
     }
 }
 
+#[derive(Debug)]
 pub struct PinPoller {
     pin_num : u64,
     epoll_fd : RawFd,


### PR DESCRIPTION
create did not work in 1.6 nightly, didn't check on stable releases

offtopic:
My fork's master branch also uses a patched nix, that works on 1.6 nightly, but doesn't work on rust 1.5 and prior versions: https://github.com/marjakm/rust-sysfs-gpio
The breakage is related to: https://github.com/rust-lang/rust/issues/29774
My nix changes have a pull request: https://github.com/carllerche/nix-rust/pull/210